### PR TITLE
disable submit button for invalid form (and not the cancel button)

### DIFF
--- a/app/events/create-event.component.html
+++ b/app/events/create-event.component.html
@@ -48,7 +48,7 @@
       <img />
     </div>
     
-    <button type="submit" class="btn btn-primary">Save</button>
-    <button type="button" [disabled]="newEventForm.invalid" class="btn btn-default" (click)="cancel()">Cancel</button>
+    <button type="submit" [disabled]="newEventForm.invalid" class="btn btn-primary">Save</button>
+    <button type="button"  class="btn btn-default" (click)="cancel()">Cancel</button>
   </form>
 </div>


### PR DESCRIPTION
moved [disabled]="newEventForm.invalid"  to the Submit button from the Cancel button